### PR TITLE
Add bias-corrected estimates to Chao1 function

### DIFF
--- a/R/Chao1.R
+++ b/R/Chao1.R
@@ -16,7 +16,41 @@ Chao1 <- function(f) {
   }
   f0 <- f0 * (x["n"] - 1) / x["n"]
   
-  x <- c(s.est = unname(f0 + s.obs), f0 = unname(f0), x)
+  # calculate bias-corrected form
+  # following Gotelli, N.J. and Colwell, R.K. (2011) Estimating Species Richness. In: Biological Diversity: Frontiers in Measurement and Assessment, Oxford University Press, United Kingdom, 39-54.
+  # https://www.uvm.edu/~ngotelli/manuscriptpdfs/Chapter%204.pdf
+  # bc stands for 'bias corrected'
+  f0.bc <- ((f[1] * (f[1] - 1)) / (2 * (f[2] + 1)))
+  s.est.bc <- s.obs + f0.bc
+
+  # calculate variance
+  # following Chao A. Estimating the population size for capture-recapture data with unequal catchability. Biometrics. 1987 Dec 1:783-91.
+  # https://doi.org/10.2307/2531532
+  if(f[1]>0 && f[2]>0){
+    variance <- f[2] * ((0.5 * ((f[1] / f[2])^2)) +
+                        ((f[1] / f[2])^3) +
+                        (0.25 * ((f[1] / f[2])^4)))
+
+    # calculate the confidence intervals (p787 of Chao 1987)
+    # here based on the bias corrected f0
+    C <- exp(1.96 * sqrt(log(1 + (variance / (s.est.bc - s.obs)^2 ))))
+
+    s.est.bc.upperCI <- s.est.bc + (f0.bc * C)
+    s.est.bc.lowerCI <- s.est.bc + (f0.bc / C)
+  } else {
+    # these are undefined if either f[1] or f[2] are 0
+    variance <- NA
+    s.est.bc.upperCI <- NA
+    s.est.bc.lowerCI <- NA
+  }
+
+  x <- c(s.est = unname(f0 + s.obs), 
+         f0 = unname(f0),
+         f0.bc = f0.bc,
+         s.est.bc = s.est.bc,
+         s.est.bc.upperCI = s.est.bc.upperCI,
+         s.est.bc.lowerCI = s.est.bc.lowerCI,
+         x)
   x[is.nan(x)] <- NA
   x
 }


### PR DESCRIPTION
Hi @EricArcher, I hope you'll consider this pull request from an undergrad class that I teach.

It's a single commit - I've updated the `Chao1()` function to add some extra outputs in the return vector, but I haven't changed anything else. The commit message (below, slightly expanded) and also the code comments should have all the info to update the documentation, but I didn't want to mess with that. 

Rob

##  Commit message (slightly expanded for clarity)

This commit adds 4 things to the return vector from the Chao1 function.

The first two are the bias-corrected values of `f0` (`f0.bc`) and `s.est` (`s.est.bc`), using formulas from ref1.

The second two are the upper and lower confidence intervals on `s.est.bc` using formulas from ref2, these are `s.est.bc.upperCI` and `s.est.bc.lowerCI`. I use the formula in equation 12, which ensures that the lower CI cannot be lower than `s.obs`. 

This is from work done by the BIOL3207 (Data Science for Biologists) class at the Australian National University.

1. Gotelli, N.J. and Colwell, R.K. (2011) Estimating Species Richness. In: Biological Diversity: Frontiers in Measurement and Assessment, Oxford University Press, United Kingdom, 39-54. https://www.uvm.edu/~ngotelli/manuscriptpdfs/Chapter%204.pdf

2. Chao A. Estimating the population size for capture-recapture data with unequal catchability. Biometrics. 1987 Dec 1:783-91. https://doi.org/10.2307/2531532